### PR TITLE
Compiles

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 trait Folder: Iterator {
-    fn foldl1<F>(mut self, f: F) -> Option<Self::Item>
+    fn foldl1<F>(self, f: F) -> Option<Self::Item>
         where
             F: FnMut(Self::Item, Self::Item) -> Self::Item;
 }
 
 impl<I> Folder for I where I: Iterator {
-    fn foldl1<F>(mut self, f: F) -> Option<Self::Item>
+    fn foldl1<F>(mut self, mut f: F) -> Option<Self::Item>
         where
             F: FnMut(Self::Item, Self::Item) -> Self::Item
     {
@@ -26,7 +26,7 @@ fn combine_all_optionf<T>(xs: &Vec<T>) -> Option<T>
     where
         T: Semigroup + Clone
 {
-    xs.iter().foldl1(|acc, next| acc.combine(next))
+    xs.clone().into_iter().foldl1(|acc, next| acc.combine(&next))
 }
 
 


### PR DESCRIPTION
It's becoming more and more clear to me that https://github.com/lloydmeta/frunk/issues/57 is the right direction to go, if only to avoid the need to have `Clone` everywhere.

I've made a bit of progress [on a branch](https://github.com/lloydmeta/frunk/tree/feature/semigroup-by-value) though.